### PR TITLE
ci: pin forge to a lower version

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Install Foundry
         uses: foundry-rs/foundry-toolchain@v1
         with:
-          version: nightly
+          version: nightly-471e4ac317858b3419faaee58ade30c0671021e0 # Nightly (2024-10-03)
 
       - name: Run tests
         run: forge test --isolate -vvv


### PR DESCRIPTION
ref: https://github.com/pancakeswap/pancake-v4-core/pull/181

did the same as test are failing now by exceeding the 6 hours limit 