### PR TITLE
[internal-s31] uniform license

### DIFF
--- a/src/MixedQuoter.sol
+++ b/src/MixedQuoter.sol
@@ -1,4 +1,5 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright (C) 2024 PancakeSwap
 pragma solidity 0.8.26;
 
 import {PoolKey} from "pancake-v4-core/src/types/PoolKey.sol";

--- a/src/V4Router.sol
+++ b/src/V4Router.sol
@@ -1,4 +1,5 @@
-// SPDX-License-Identifier: UNLICENSED
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright (C) 2024 PancakeSwap
 pragma solidity ^0.8.24;
 
 import {IVault} from "pancake-v4-core/src/interfaces/IVault.sol";

--- a/src/base/BaseActionsRouter.sol
+++ b/src/base/BaseActionsRouter.sol
@@ -1,4 +1,5 @@
-// SPDX-License-Identifier: GPL-3.0-or-later
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright (C) 2024 PancakeSwap
 pragma solidity ^0.8.24;
 
 import {IVault} from "pancake-v4-core/src/interfaces/IVault.sol";

--- a/src/base/DeltaResolver.sol
+++ b/src/base/DeltaResolver.sol
@@ -1,4 +1,5 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright (C) 2024 PancakeSwap
 pragma solidity ^0.8.24;
 
 import {Currency} from "pancake-v4-core/src/types/Currency.sol";

--- a/src/base/ImmutableState.sol
+++ b/src/base/ImmutableState.sol
@@ -1,4 +1,5 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright (C) 2024 PancakeSwap
 pragma solidity ^0.8.0;
 
 import {IVault} from "pancake-v4-core/src/interfaces/IVault.sol";

--- a/src/base/Multicall_v4.sol
+++ b/src/base/Multicall_v4.sol
@@ -1,4 +1,5 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright (C) 2024 PancakeSwap
 pragma solidity ^0.8.0;
 
 import {IMulticall_v4} from "../interfaces/IMulticall_v4.sol";

--- a/src/base/NativeWrapper.sol
+++ b/src/base/NativeWrapper.sol
@@ -1,4 +1,5 @@
-// SPDX-License-Identifier: UNLICENSED
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright (C) 2024 PancakeSwap
 pragma solidity ^0.8.0;
 
 import {IWETH9} from "../interfaces/external/IWETH9.sol";

--- a/src/base/Permit2Forwarder.sol
+++ b/src/base/Permit2Forwarder.sol
@@ -1,4 +1,5 @@
-// SPDX-License-Identifier: GPL-3.0-or-later
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright (C) 2024 PancakeSwap
 pragma solidity ^0.8.0;
 
 import {IAllowanceTransfer} from "permit2/src/interfaces/IAllowanceTransfer.sol";

--- a/src/base/ReentrancyLock.sol
+++ b/src/base/ReentrancyLock.sol
@@ -1,4 +1,5 @@
-// SPDX-License-Identifier: GPL-3.0-or-later
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright (C) 2024 PancakeSwap
 pragma solidity ^0.8.24;
 
 /// @notice A transient reentrancy lock, that stores the caller's address as the lock

--- a/src/base/SafeCallback.sol
+++ b/src/base/SafeCallback.sol
@@ -1,4 +1,5 @@
-// SPDX-License-Identifier: GPL-3.0-or-later
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright (C) 2024 PancakeSwap
 pragma solidity ^0.8.24;
 
 import {ILockCallback} from "pancake-v4-core/src/interfaces/ILockCallback.sol";

--- a/src/interfaces/IBaseMigrator.sol
+++ b/src/interfaces/IBaseMigrator.sol
@@ -1,5 +1,4 @@
-// SPDX-License-Identifier: GPL-2.0-or-later
-// Copyright (C) 2024 PancakeSwap
+// SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 
 import {PoolKey} from "pancake-v4-core/src/types/PoolKey.sol";

--- a/src/interfaces/IImmutableState.sol
+++ b/src/interfaces/IImmutableState.sol
@@ -1,5 +1,4 @@
-// SPDX-License-Identifier: GPL-2.0-or-later
-// Copyright (C) 2024 PancakeSwap
+// SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 
 import {IVault} from "pancake-v4-core/src/interfaces/IVault.sol";

--- a/src/interfaces/IMixedQuoter.sol
+++ b/src/interfaces/IMixedQuoter.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: UNLICENSED
+// SPDX-License-Identifier: MIT
 pragma solidity ^0.8.24;
 
 import {PoolKey} from "pancake-v4-core/src/types/PoolKey.sol";

--- a/src/interfaces/IMulticall_v4.sol
+++ b/src/interfaces/IMulticall_v4.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: UNLICENSED
+// SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 
 /// @title Multicall_v4 interface

--- a/src/interfaces/IPoolManager.sol
+++ b/src/interfaces/IPoolManager.sol
@@ -1,5 +1,4 @@
-// SPDX-License-Identifier: GPL-2.0-or-later
-// Copyright (C) 2024 PancakeSwap
+// SPDX-License-Identifier: MIT
 pragma solidity ^0.8.24;
 
 import {IVault} from "pancake-v4-core/src/interfaces/IVault.sol";

--- a/src/interfaces/IPositionManager.sol
+++ b/src/interfaces/IPositionManager.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: UNLICENSED
+// SPDX-License-Identifier: MIT
 pragma solidity ^0.8.24;
 
 import {IImmutableState} from "./IImmutableState.sol";

--- a/src/interfaces/IPositionManagerPermit2.sol
+++ b/src/interfaces/IPositionManagerPermit2.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: UNLICENSED
+// SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 
 import {IAllowanceTransfer} from "permit2/src/interfaces/IAllowanceTransfer.sol";

--- a/src/interfaces/IQuoter.sol
+++ b/src/interfaces/IQuoter.sol
@@ -1,5 +1,4 @@
-// SPDX-License-Identifier: GPL-2.0-or-later
-// Copyright (C) 2024 PancakeSwap
+// SPDX-License-Identifier: MIT
 pragma solidity ^0.8.24;
 
 import {Currency} from "pancake-v4-core/src/types/Currency.sol";

--- a/src/interfaces/IV4Router.sol
+++ b/src/interfaces/IV4Router.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: UNLICENSED
+// SPDX-License-Identifier: MIT
 pragma solidity ^0.8.24;
 
 import {PoolKey} from "pancake-v4-core/src/types/PoolKey.sol";

--- a/src/libraries/ActionConstants.sol
+++ b/src/libraries/ActionConstants.sol
@@ -1,4 +1,5 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright (C) 2024 PancakeSwap
 pragma solidity ^0.8.0;
 
 /// @title Action Constants

--- a/src/libraries/Actions.sol
+++ b/src/libraries/Actions.sol
@@ -1,4 +1,5 @@
-// SPDX-License-Identifier: GPL-3.0-or-later
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright (C) 2024 PancakeSwap
 pragma solidity ^0.8.0;
 
 /// @notice Library to define different pool actions.

--- a/src/libraries/BipsLibrary.sol
+++ b/src/libraries/BipsLibrary.sol
@@ -1,4 +1,5 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright (C) 2024 PancakeSwap
 pragma solidity ^0.8.0;
 
 /// @title For calculating a percentage of an amount, using bips

--- a/src/libraries/CalldataDecoder.sol
+++ b/src/libraries/CalldataDecoder.sol
@@ -1,4 +1,5 @@
-// SPDX-License-Identifier: GPL-3.0-or-later
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright (C) 2024 PancakeSwap
 pragma solidity ^0.8.0;
 
 import {Currency} from "pancake-v4-core/src/types/Currency.sol";

--- a/src/libraries/MixedQuoterActions.sol
+++ b/src/libraries/MixedQuoterActions.sol
@@ -1,4 +1,5 @@
-// SPDX-License-Identifier: GPL-3.0-or-later
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright (C) 2024 PancakeSwap
 pragma solidity ^0.8.0;
 
 /// @notice Library to define different mixed quoter actions.

--- a/src/libraries/PathKey.sol
+++ b/src/libraries/PathKey.sol
@@ -1,4 +1,5 @@
-//SPDX-License-Identifier: UNLICENSED
+//SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright (C) 2024 PancakeSwap
 pragma solidity ^0.8.0;
 
 import {Currency} from "pancake-v4-core/src/types/Currency.sol";

--- a/src/libraries/Planner.sol
+++ b/src/libraries/Planner.sol
@@ -1,4 +1,5 @@
-// SPDX-License-Identifier: UNLICENSED
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright (C) 2024 PancakeSwap
 pragma solidity ^0.8.0;
 
 import {PoolKey} from "pancake-v4-core/src/types/PoolKey.sol";

--- a/src/libraries/SafeCast.sol
+++ b/src/libraries/SafeCast.sol
@@ -1,4 +1,5 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright (C) 2024 PancakeSwap
 pragma solidity ^0.8.0;
 
 /// @title Safe casting methods

--- a/src/libraries/SlippageCheck.sol
+++ b/src/libraries/SlippageCheck.sol
@@ -1,4 +1,5 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright (C) 2024 PancakeSwap
 pragma solidity ^0.8.0;
 
 import {BalanceDelta} from "pancake-v4-core/src/types/BalanceDelta.sol";

--- a/src/pool-bin/interfaces/IBinFungibleToken.sol
+++ b/src/pool-bin/interfaces/IBinFungibleToken.sol
@@ -1,5 +1,4 @@
-// SPDX-License-Identifier: GPL-2.0-or-later
-// Copyright (C) 2024 PancakeSwap
+// SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 
 interface IBinFungibleToken {

--- a/src/pool-bin/interfaces/IBinMigrator.sol
+++ b/src/pool-bin/interfaces/IBinMigrator.sol
@@ -1,5 +1,4 @@
-// SPDX-License-Identifier: GPL-2.0-or-later
-// Copyright (C) 2024 PancakeSwap
+// SPDX-License-Identifier: MIT
 pragma solidity ^0.8.24;
 
 import {PoolKey} from "pancake-v4-core/src/types/PoolKey.sol";

--- a/src/pool-bin/interfaces/IBinPositionManager.sol
+++ b/src/pool-bin/interfaces/IBinPositionManager.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: UNLICENSED
+// SPDX-License-Identifier: MIT
 pragma solidity ^0.8.24;
 
 import {PoolId} from "pancake-v4-core/src/types/PoolId.sol";

--- a/src/pool-bin/interfaces/IBinQuoter.sol
+++ b/src/pool-bin/interfaces/IBinQuoter.sol
@@ -1,5 +1,4 @@
-// SPDX-License-Identifier: GPL-2.0-or-later
-// Copyright (C) 2024 PancakeSwap
+// SPDX-License-Identifier: MIT
 pragma solidity ^0.8.24;
 
 import {IQuoter} from "../../interfaces/IQuoter.sol";

--- a/src/pool-bin/interfaces/IBinRouterBase.sol
+++ b/src/pool-bin/interfaces/IBinRouterBase.sol
@@ -1,5 +1,4 @@
-// SPDX-License-Identifier: GPL-2.0-or-later
-// Copyright (C) 2024 PancakeSwap
+// SPDX-License-Identifier: MIT
 pragma solidity ^0.8.24;
 
 import {PoolKey} from "pancake-v4-core/src/types/PoolKey.sol";

--- a/src/pool-bin/libraries/BinCalldataDecoder.sol
+++ b/src/pool-bin/libraries/BinCalldataDecoder.sol
@@ -1,4 +1,5 @@
-// SPDX-License-Identifier: GPL-3.0-or-later
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright (C) 2024 PancakeSwap
 pragma solidity ^0.8.0;
 
 import {IBinPositionManager} from "../interfaces/IBinPositionManager.sol";

--- a/src/pool-cl/base/CLNotifier.sol
+++ b/src/pool-cl/base/CLNotifier.sol
@@ -1,4 +1,5 @@
-// SPDX-License-Identifier: GPL-3.0-or-later
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright (C) 2024 PancakeSwap
 pragma solidity ^0.8.0;
 
 import {ICLSubscriber} from "../interfaces/ICLSubscriber.sol";

--- a/src/pool-cl/base/ERC721Permit_v4.sol
+++ b/src/pool-cl/base/ERC721Permit_v4.sol
@@ -1,4 +1,5 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright (C) 2024 PancakeSwap
 pragma solidity ^0.8.0;
 
 import {ERC721} from "solmate/src/tokens/ERC721.sol";

--- a/src/pool-cl/base/UnorderedNonce.sol
+++ b/src/pool-cl/base/UnorderedNonce.sol
@@ -1,4 +1,5 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright (C) 2024 PancakeSwap
 pragma solidity ^0.8.0;
 
 /// @title Unordered Nonce

--- a/src/pool-cl/interfaces/ICLMigrator.sol
+++ b/src/pool-cl/interfaces/ICLMigrator.sol
@@ -1,5 +1,4 @@
-// SPDX-License-Identifier: GPL-2.0-or-later
-// Copyright (C) 2024 PancakeSwap
+// SPDX-License-Identifier: MIT
 pragma solidity ^0.8.24;
 
 import {PoolKey} from "pancake-v4-core/src/types/PoolKey.sol";

--- a/src/pool-cl/interfaces/ICLNotifier.sol
+++ b/src/pool-cl/interfaces/ICLNotifier.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: UNLICENSED
+// SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 
 import {ICLSubscriber} from "./ICLSubscriber.sol";

--- a/src/pool-cl/interfaces/ICLPositionDescriptor.sol
+++ b/src/pool-cl/interfaces/ICLPositionDescriptor.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: GPL-2.0-or-later
+// SPDX-License-Identifier: MIT
 pragma solidity ^0.8.24;
 
 import {ICLPositionManager} from "./ICLPositionManager.sol";

--- a/src/pool-cl/interfaces/ICLPositionManager.sol
+++ b/src/pool-cl/interfaces/ICLPositionManager.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: UNLICENSED
+// SPDX-License-Identifier: MIT
 pragma solidity ^0.8.24;
 
 import {PoolKey} from "pancake-v4-core/src/types/PoolKey.sol";

--- a/src/pool-cl/interfaces/ICLQuoter.sol
+++ b/src/pool-cl/interfaces/ICLQuoter.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: GPL-2.0-or-later
+// SPDX-License-Identifier: MIT
 pragma solidity ^0.8.24;
 
 import {IQuoter} from "../../interfaces/IQuoter.sol";

--- a/src/pool-cl/interfaces/ICLRouterBase.sol
+++ b/src/pool-cl/interfaces/ICLRouterBase.sol
@@ -1,5 +1,4 @@
-// SPDX-License-Identifier: GPL-2.0-or-later
-// Copyright (C) 2024 PancakeSwap
+// SPDX-License-Identifier: MIT
 pragma solidity ^0.8.24;
 
 import {Currency} from "pancake-v4-core/src/types/Currency.sol";

--- a/src/pool-cl/interfaces/ICLSubscriber.sol
+++ b/src/pool-cl/interfaces/ICLSubscriber.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: UNLICENSED
+// SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 
 import {BalanceDelta} from "pancake-v4-core/src/types/BalanceDelta.sol";

--- a/src/pool-cl/interfaces/IERC721Permit.sol
+++ b/src/pool-cl/interfaces/IERC721Permit.sol
@@ -1,5 +1,4 @@
-// SPDX-License-Identifier: GPL-2.0-or-later
-// Copyright (C) 2024 PancakeSwap
+// SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 
 import "@openzeppelin/contracts/token/ERC721/IERC721.sol";

--- a/src/pool-cl/interfaces/IERC721Permit_v4.sol
+++ b/src/pool-cl/interfaces/IERC721Permit_v4.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: GPL-2.0-or-later
+// SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 
 /// @title ERC721 with permit

--- a/src/pool-cl/interfaces/ITickLens.sol
+++ b/src/pool-cl/interfaces/ITickLens.sol
@@ -1,4 +1,4 @@
-// SPDX-License-Identifier: GPL-2.0-or-later
+// SPDX-License-Identifier: MIT
 pragma solidity 0.8.26;
 
 import {PoolKey} from "pancake-v4-core/src/types/PoolKey.sol";

--- a/src/pool-cl/lens/CLQuoter.sol
+++ b/src/pool-cl/lens/CLQuoter.sol
@@ -1,4 +1,5 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright (C) 2024 PancakeSwap
 pragma solidity 0.8.26;
 
 import {TickMath} from "pancake-v4-core/src/pool-cl/libraries/TickMath.sol";

--- a/src/pool-cl/lens/TickLens.sol
+++ b/src/pool-cl/lens/TickLens.sol
@@ -1,4 +1,5 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright (C) 2024 PancakeSwap
 pragma solidity 0.8.26;
 
 import {PoolKey} from "pancake-v4-core/src/types/PoolKey.sol";

--- a/src/pool-cl/libraries/CLCalldataDecoder.sol
+++ b/src/pool-cl/libraries/CLCalldataDecoder.sol
@@ -1,4 +1,5 @@
-// SPDX-License-Identifier: GPL-3.0-or-later
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright (C) 2024 PancakeSwap
 pragma solidity ^0.8.0;
 
 import {IV4Router} from "../../interfaces/IV4Router.sol";

--- a/src/pool-cl/libraries/CLPositionInfoLibrary.sol
+++ b/src/pool-cl/libraries/CLPositionInfoLibrary.sol
@@ -1,4 +1,5 @@
-// SPDX-License-Identifier: UNLICENSED
+// SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright (C) 2024 PancakeSwap
 pragma solidity ^0.8.24;
 
 import {PoolKey} from "pancake-v4-core/src/types/PoolKey.sol";

--- a/src/pool-cl/libraries/ERC721PermitHash.sol
+++ b/src/pool-cl/libraries/ERC721PermitHash.sol
@@ -1,4 +1,5 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright (C) 2024 PancakeSwap
 pragma solidity ^0.8.0;
 
 library ERC721PermitHash {

--- a/src/pool-cl/libraries/PoolTicksCounter.sol
+++ b/src/pool-cl/libraries/PoolTicksCounter.sol
@@ -1,4 +1,5 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
+// Copyright (C) 2024 PancakeSwap
 pragma solidity ^0.8.24;
 
 import {CLPoolParametersHelper} from "pancake-v4-core/src/pool-cl/libraries/CLPoolParametersHelper.sol";


### PR DESCRIPTION
Per previous agreement:

1. interfaces will be `MIT`
2. updated gpl-3 back to gpl-2 to be consistent with other files and include `// Copyright (C) 2024 PancakeSwap` for those files 