### PR TITLE
[Part 2 of 3] Increase optimizer runs (s41)

### DIFF
--- a/foundry.toml
+++ b/foundry.toml
@@ -2,7 +2,7 @@
 src = 'src'
 out = 'foundry-out'
 solc_version = '0.8.26'
-optimizer_runs = 9000
+optimizer_runs = 1_000_000
 via_ir = true
 ffi = true
 gas_limit = "3000000000"
@@ -14,6 +14,14 @@ fs_permissions = [
 ]
 evm_version = 'cancun'
 bytecode_hash = "none"
+
+additional_compiler_profiles = [
+  { name = "clPosm", optimizer_runs = 9000 }
+]
+
+compilation_restrictions = [
+  { paths = "src/pool-cl/CLPositionManager.sol", optimizer_runs = 9000 }
+]
 
 [fuzz]
 runs = 5 # change this for higher number of fuzz runs locally

--- a/snapshots/BaseActionsRouterTest.json
+++ b/snapshots/BaseActionsRouterTest.json
@@ -1,3 +1,3 @@
 {
-  "mock10commands": "82833"
+  "mock10commands": "82785"
 }

--- a/snapshots/BinMigratorFromPancakeswapV2Test.json
+++ b/snapshots/BinMigratorFromPancakeswapV2Test.json
@@ -1,5 +1,5 @@
 {
-  "testMigrateFromV2IncludingInit": "1180066",
-  "testMigrateFromV2WithoutInit": "1049481",
-  "testMigrateFromV2WithoutNativeToken": "1090203"
+  "testMigrateFromV2IncludingInit": "1176442",
+  "testMigrateFromV2WithoutInit": "1046490",
+  "testMigrateFromV2WithoutNativeToken": "1087310"
 }

--- a/snapshots/BinMigratorFromPancakeswapV3Test.json
+++ b/snapshots/BinMigratorFromPancakeswapV3Test.json
@@ -1,6 +1,6 @@
 {
-  "BinMigratorBytecode size": "12601",
-  "testMigrateFromV3IncludingInit": "1252393",
-  "testMigrateFromV3WithoutInit": "1121789",
-  "testMigrateFromV3WithoutNativeToken": "1156506"
+  "BinMigratorBytecode size": "15187",
+  "testMigrateFromV3IncludingInit": "1248658",
+  "testMigrateFromV3WithoutInit": "1118687",
+  "testMigrateFromV3WithoutNativeToken": "1153511"
 }

--- a/snapshots/BinMigratorFromUniswapV2Test.json
+++ b/snapshots/BinMigratorFromUniswapV2Test.json
@@ -1,5 +1,5 @@
 {
-  "testMigrateFromV2IncludingInit": "1180066",
-  "testMigrateFromV2WithoutInit": "1049481",
-  "testMigrateFromV2WithoutNativeToken": "1090203"
+  "testMigrateFromV2IncludingInit": "1176442",
+  "testMigrateFromV2WithoutInit": "1046490",
+  "testMigrateFromV2WithoutNativeToken": "1087310"
 }

--- a/snapshots/BinMigratorFromUniswapV3Test.json
+++ b/snapshots/BinMigratorFromUniswapV3Test.json
@@ -1,6 +1,6 @@
 {
-  "BinMigratorBytecode size": "12601",
-  "testMigrateFromV3IncludingInit": "1250375",
-  "testMigrateFromV3WithoutInit": "1119771",
-  "testMigrateFromV3WithoutNativeToken": "1154488"
+  "BinMigratorBytecode size": "15187",
+  "testMigrateFromV3IncludingInit": "1246640",
+  "testMigrateFromV3WithoutInit": "1116669",
+  "testMigrateFromV3WithoutNativeToken": "1151493"
 }

--- a/snapshots/BinPositionManagerTest.json
+++ b/snapshots/BinPositionManagerTest.json
@@ -1,3 +1,3 @@
 {
-  "BinPositionManagerBytecode size": "15154"
+  "BinPositionManagerBytecode size": "17435"
 }

--- a/snapshots/BinPositionManager_ModifyLiquidityTest.json
+++ b/snapshots/BinPositionManager_ModifyLiquidityTest.json
@@ -1,7 +1,7 @@
 {
-  "test_addLiquidity_OutsideActiveId": "294827",
-  "test_addLiquidity_SingleBin": "533778",
-  "test_addLiquidity_ThreeBins": "908043",
-  "test_decreaseLiquidity_threeBins": "186051",
-  "test_decreaseLiquidity_threeBins_half": "205238"
+  "test_addLiquidity_OutsideActiveId": "292694",
+  "test_addLiquidity_SingleBin": "532073",
+  "test_addLiquidity_ThreeBins": "905930",
+  "test_decreaseLiquidity_threeBins": "184859",
+  "test_decreaseLiquidity_threeBins_half": "203748"
 }

--- a/snapshots/BinPositionManager_NativeTokenTest.json
+++ b/snapshots/BinPositionManager_NativeTokenTest.json
@@ -1,5 +1,5 @@
 {
-  "test_addLiquidity": "849375",
-  "test_addLiquidity_excessEth": "851136",
-  "test_decreaseLiquidity": "192695"
+  "test_addLiquidity": "847340",
+  "test_addLiquidity_excessEth": "849077",
+  "test_decreaseLiquidity": "191515"
 }

--- a/snapshots/BinQuoterTest.json
+++ b/snapshots/BinQuoterTest.json
@@ -1,3 +1,3 @@
 {
-  "BinQuoterBytecode size": "6299"
+  "BinQuoterBytecode size": "6839"
 }

--- a/snapshots/BinSwapRouterTest.json
+++ b/snapshots/BinSwapRouterTest.json
@@ -1,9 +1,9 @@
 {
-  "testExactInputSingle_DifferentRecipient": "137214",
-  "testExactInputSingle_EthPool_SwapEthForToken": "125543",
-  "testExactInputSingle_EthPool_SwapTokenForEth": "111288",
-  "testExactInput_MultiHopDifferentRecipient": "168754",
-  "testExactOutputSingle_DifferentRecipient": "141480",
-  "testExactOutput_MultiHopDifferentRecipient": "172390",
-  "testExactOutput_SingleHop": "143161"
+  "testExactInputSingle_DifferentRecipient": "136133",
+  "testExactInputSingle_EthPool_SwapEthForToken": "124501",
+  "testExactInputSingle_EthPool_SwapTokenForEth": "110210",
+  "testExactInput_MultiHopDifferentRecipient": "166964",
+  "testExactOutputSingle_DifferentRecipient": "140509",
+  "testExactOutput_MultiHopDifferentRecipient": "170820",
+  "testExactOutput_SingleHop": "142184"
 }

--- a/snapshots/CLPositionDescriptorOffChainTest.json
+++ b/snapshots/CLPositionDescriptorOffChainTest.json
@@ -1,3 +1,3 @@
 {
-  "CLPositionDescriptorOffChain size": "2568"
+  "CLPositionDescriptorOffChain size": "2958"
 }

--- a/snapshots/CLQuoterTest.json
+++ b/snapshots/CLQuoterTest.json
@@ -1,3 +1,3 @@
 {
-  "CLQuoterBytecode size": "6458"
+  "CLQuoterBytecode size": "6998"
 }

--- a/snapshots/CLSwapRouterTest.json
+++ b/snapshots/CLSwapRouterTest.json
@@ -1,6 +1,6 @@
 {
-  "testExactInputSingle_gas": "169788",
-  "testExactInput_gas": "234192",
-  "testExactOutputSingle_gas": "169491",
-  "testExactOutput_gas": "233092"
+  "testExactInputSingle_gas": "168817",
+  "testExactInput_gas": "232455",
+  "testExactOutputSingle_gas": "168510",
+  "testExactOutput_gas": "231337"
 }

--- a/src/interfaces/IBaseMigrator.sol
+++ b/src/interfaces/IBaseMigrator.sol
@@ -5,6 +5,8 @@ import {PoolKey} from "pancake-v4-core/src/types/PoolKey.sol";
 import {IMulticall_v4} from "./IMulticall_v4.sol";
 import {ISelfPermitERC721} from "./ISelfPermitERC721.sol";
 
+/// @title IBaseMigrator
+/// @notice Interface for the BaseMigrator contract
 interface IBaseMigrator is IMulticall_v4, ISelfPermitERC721 {
     error TOKEN_NOT_MATCH();
     error INVALID_ETHER_SENDER();

--- a/src/interfaces/IImmutableState.sol
+++ b/src/interfaces/IImmutableState.sol
@@ -3,7 +3,8 @@ pragma solidity ^0.8.0;
 
 import {IVault} from "pancake-v4-core/src/interfaces/IVault.sol";
 
-/// @title Interface for ImmutableState
+/// @title IImmutableState
+/// @notice Interface for the ImmutableState contract
 interface IImmutableState {
     /// @notice The Pancakeswap v4 Vault contract
     function vault() external view returns (IVault);

--- a/src/interfaces/IPoolManager.sol
+++ b/src/interfaces/IPoolManager.sol
@@ -3,6 +3,8 @@ pragma solidity ^0.8.24;
 
 import {IVault} from "pancake-v4-core/src/interfaces/IVault.sol";
 
+/// @title IPoolManager
+/// @notice Interface for the PoolManager contract
 interface IPoolManager {
     /// @notice Returns the vault contract
     /// @return IVault The address of the vault

--- a/src/interfaces/IPositionManager.sol
+++ b/src/interfaces/IPositionManager.sol
@@ -3,6 +3,8 @@ pragma solidity ^0.8.24;
 
 import {IImmutableState} from "./IImmutableState.sol";
 
+/// @title IPositionManager
+/// @notice Interface for the PositionManager contract
 interface IPositionManager is IImmutableState {
     /// @notice Thrown when the block.timestamp exceeds the user-provided deadline
     error DeadlinePassed(uint256 deadline);

--- a/src/interfaces/IPositionManagerPermit2.sol
+++ b/src/interfaces/IPositionManagerPermit2.sol
@@ -3,6 +3,8 @@ pragma solidity ^0.8.0;
 
 import {IAllowanceTransfer} from "permit2/src/interfaces/IAllowanceTransfer.sol";
 
+/// @title IPositionManagerPermit2
+/// @notice Interface for the IPositionManagerPermit2 contract
 interface IPositionManagerPermit2 {
     function permit2() external view returns (IAllowanceTransfer);
 }

--- a/src/interfaces/IQuoter.sol
+++ b/src/interfaces/IQuoter.sol
@@ -6,7 +6,7 @@ import {PathKey} from "../libraries/PathKey.sol";
 import {PoolKey} from "pancake-v4-core/src/types/PoolKey.sol";
 import {PoolId} from "pancake-v4-core/src/types/PoolId.sol";
 
-/// @title IQuoter Interface
+/// @title IQuoter
 /// @notice Supports quoting the delta amounts from exact input or exact output swaps.
 /// @dev These functions are not marked view because they rely on calling non-view functions and reverting
 /// to compute the result. They are also not gas efficient and should not be called on-chain.

--- a/src/interfaces/ISelfPermit.sol
+++ b/src/interfaces/ISelfPermit.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 
-/// @title Self Permit
+/// @title ISelfPermit
 /// @notice Functionality to call permit on any EIP-2612-compliant token for use in the route
 interface ISelfPermit {
     /// @notice Permits this contract to spend a given token from `msg.sender`

--- a/src/interfaces/ISelfPermitERC721.sol
+++ b/src/interfaces/ISelfPermitERC721.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 
-/// @title Self Permit For ERC721
+/// @title ISelfPermitERC721
 /// @notice Functionality to call permit on any EIP-2612-compliant token
 /// This is for PancakeSwapV3 styled Nonfungible Position Manager which supports permit extension
 interface ISelfPermitERC721 {

--- a/src/interfaces/external/IERC20PermitAllowed.sol
+++ b/src/interfaces/external/IERC20PermitAllowed.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 pragma solidity ^0.8.0;
 
-/// @title Interface for permit
+/// @title IERC20PermitAllowed
 /// @notice Interface used by DAI/CHAI for permit
 interface IERC20PermitAllowed {
     /// @notice Approve the spender to spend some tokens via the holder signature

--- a/src/interfaces/external/IPancakeFactory.sol
+++ b/src/interfaces/external/IPancakeFactory.sol
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 pragma solidity ^0.8.0;
 
+/// @title IPancakeFactory
+/// @notice Interface for the PancakeFactory contract
 interface IPancakeFactory {
     function getPair(address tokenA, address tokenB) external view returns (address pair);
     function createPair(address tokenA, address tokenB) external returns (address pair);

--- a/src/interfaces/external/IPancakePair.sol
+++ b/src/interfaces/external/IPancakePair.sol
@@ -1,7 +1,8 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 pragma solidity ^0.8.0;
 
-/// @notice Copying from PancakeSwap V2 Pair
+/// @title IPancakePair
+/// @notice Interface for the PancakeSwap V2 Pair
 /// https://github.com/pancakeswap/pancake-swap-core-v2/blob/master/contracts/interfaces/IPancakePair.sol
 interface IPancakePair {
     event Approval(address indexed owner, address indexed spender, uint256 value);

--- a/src/interfaces/external/IPancakeV3Factory.sol
+++ b/src/interfaces/external/IPancakeV3Factory.sol
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 pragma solidity ^0.8.0;
 
+/// @title IPancakeV3Factory
+/// @notice Interface for the PancakeV3Factory contract
 interface IPancakeV3Factory {
     /// @notice Returns the pool address for a given pair of tokens and a fee, or address 0 if it does not exist
     /// @dev tokenA and tokenB may be passed in either token0/token1 or token1/token0 order

--- a/src/interfaces/external/IPancakeV3Pool.sol
+++ b/src/interfaces/external/IPancakeV3Pool.sol
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 pragma solidity ^0.8.0;
 
+/// @title IPancakeV3Pool
+/// @notice Interface for the PancakeV3Pool contract
 interface IPancakeV3Pool {
     /// @notice The 0th storage slot in the pool stores many values, and is exposed as a single method to save gas
     /// when accessed externally.

--- a/src/interfaces/external/IPancakeV3SwapCallback.sol
+++ b/src/interfaces/external/IPancakeV3SwapCallback.sol
@@ -1,8 +1,9 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 pragma solidity ^0.8.0;
 
-/// @title Callback for IPancakeV3PoolActions#swap
-/// @notice Any contract that calls IPancakeV3PoolActions#swap must implement this interface
+/// @title IPancakeV3SwapCallback
+/// @notice Callback for IPancakeV3PoolActions#swap
+/// @dev Any contract that calls IPancakeV3PoolActions#swap must implement this interface.
 interface IPancakeV3SwapCallback {
     /// @notice Called to `msg.sender` after executing a swap via IPancakeV3Pool#swap.
     /// @dev In the implementation you must pay the pool tokens owed for the swap.

--- a/src/interfaces/external/IStableSwap.sol
+++ b/src/interfaces/external/IStableSwap.sol
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 pragma solidity ^0.8.0;
 
+/// @title IStableSwap
+/// @notice Interface for the StableSwap contract
 interface IStableSwap {
     // solium-disable-next-line mixedcase
     function get_dy(uint256 i, uint256 j, uint256 dx) external view returns (uint256 dy);

--- a/src/interfaces/external/IStableSwapFactory.sol
+++ b/src/interfaces/external/IStableSwapFactory.sol
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 pragma solidity ^0.8.0;
 
+/// @title IStableSwapFactory
+/// @notice Interface for the StableSwapFactory contract
 interface IStableSwapFactory {
     struct StableSwapPairInfo {
         address swapContract;

--- a/src/interfaces/external/IV3NonfungiblePositionManager.sol
+++ b/src/interfaces/external/IV3NonfungiblePositionManager.sol
@@ -3,7 +3,7 @@ pragma solidity ^0.8.0;
 
 import {IERC721Permit} from "../../pool-cl/interfaces/IERC721Permit.sol";
 
-/// @title Non-fungible token for positions
+/// @title IV3NonfungiblePositionManager
 /// @notice Wraps PancakeSwap V3 positions in a non-fungible token interface which allows for them to be transferred
 /// and authorized. Copying from PancakeSwap-V3
 /// https://github.com/pancakeswap/pancake-v3-contracts/blob/main/projects/v3-periphery/contracts/interfaces/INonfungiblePositionManager.sol

--- a/src/interfaces/external/IWETH9.sol
+++ b/src/interfaces/external/IWETH9.sol
@@ -3,7 +3,8 @@ pragma solidity ^0.8.0;
 
 import {IERC20} from "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 
-/// @title Interface for WETH9
+/// @title IWETH9
+/// @notice Interface for WETH9
 interface IWETH9 is IERC20 {
     /// @notice Deposit ether to get wrapped ether
     function deposit() external payable;

--- a/src/libraries/Actions.sol
+++ b/src/libraries/Actions.sol
@@ -8,55 +8,55 @@ pragma solidity ^0.8.0;
 library Actions {
     // cl-pool actions
     // liquidity actions
-    uint256 constant CL_INCREASE_LIQUIDITY = 0x00;
-    uint256 constant CL_DECREASE_LIQUIDITY = 0x01;
-    uint256 constant CL_MINT_POSITION = 0x02;
-    uint256 constant CL_BURN_POSITION = 0x03;
-    uint256 constant CL_INCREASE_LIQUIDITY_FROM_DELTAS = 0x04;
-    uint256 constant CL_MINT_POSITION_FROM_DELTAS = 0x05;
+    uint256 internal constant CL_INCREASE_LIQUIDITY = 0x00;
+    uint256 internal constant CL_DECREASE_LIQUIDITY = 0x01;
+    uint256 internal constant CL_MINT_POSITION = 0x02;
+    uint256 internal constant CL_BURN_POSITION = 0x03;
+    uint256 internal constant CL_INCREASE_LIQUIDITY_FROM_DELTAS = 0x04;
+    uint256 internal constant CL_MINT_POSITION_FROM_DELTAS = 0x05;
 
     // swapping
-    uint256 constant CL_SWAP_EXACT_IN_SINGLE = 0x06;
-    uint256 constant CL_SWAP_EXACT_IN = 0x07;
-    uint256 constant CL_SWAP_EXACT_OUT_SINGLE = 0x08;
-    uint256 constant CL_SWAP_EXACT_OUT = 0x09;
+    uint256 internal constant CL_SWAP_EXACT_IN_SINGLE = 0x06;
+    uint256 internal constant CL_SWAP_EXACT_IN = 0x07;
+    uint256 internal constant CL_SWAP_EXACT_OUT_SINGLE = 0x08;
+    uint256 internal constant CL_SWAP_EXACT_OUT = 0x09;
 
     // donate
     /// @dev this is not supported in the position manager or router
-    uint256 constant CL_DONATE = 0x0a;
+    uint256 internal constant CL_DONATE = 0x0a;
 
     // closing deltas on the pool manager
     // settling
-    uint256 constant SETTLE = 0x0b;
-    uint256 constant SETTLE_ALL = 0x0c;
-    uint256 constant SETTLE_PAIR = 0x0d;
+    uint256 internal constant SETTLE = 0x0b;
+    uint256 internal constant SETTLE_ALL = 0x0c;
+    uint256 internal constant SETTLE_PAIR = 0x0d;
     // taking
-    uint256 constant TAKE = 0x0e;
-    uint256 constant TAKE_ALL = 0x0f;
-    uint256 constant TAKE_PORTION = 0x10;
-    uint256 constant TAKE_PAIR = 0x11;
+    uint256 internal constant TAKE = 0x0e;
+    uint256 internal constant TAKE_ALL = 0x0f;
+    uint256 internal constant TAKE_PORTION = 0x10;
+    uint256 internal constant TAKE_PAIR = 0x11;
 
-    uint256 constant CLOSE_CURRENCY = 0x12;
-    uint256 constant CLEAR_OR_TAKE = 0x13;
-    uint256 constant SWEEP = 0x14;
-    uint256 constant WRAP = 0x15;
-    uint256 constant UNWRAP = 0x16;
+    uint256 internal constant CLOSE_CURRENCY = 0x12;
+    uint256 internal constant CLEAR_OR_TAKE = 0x13;
+    uint256 internal constant SWEEP = 0x14;
+    uint256 internal constant WRAP = 0x15;
+    uint256 internal constant UNWRAP = 0x16;
 
     // minting/burning 6909s to close deltas
     /// @dev this is not supported in the position manager or router
-    uint256 constant MINT_6909 = 0x17;
-    uint256 constant BURN_6909 = 0x18;
+    uint256 internal constant MINT_6909 = 0x17;
+    uint256 internal constant BURN_6909 = 0x18;
 
     // bin-pool actions
     // liquidity actions
-    uint256 constant BIN_ADD_LIQUIDITY = 0x19;
-    uint256 constant BIN_REMOVE_LIQUIDITY = 0x1a;
-    uint256 constant BIN_ADD_LIQUIDITY_FROM_DELTAS = 0x1b;
+    uint256 internal constant BIN_ADD_LIQUIDITY = 0x19;
+    uint256 internal constant BIN_REMOVE_LIQUIDITY = 0x1a;
+    uint256 internal constant BIN_ADD_LIQUIDITY_FROM_DELTAS = 0x1b;
     // swapping
-    uint256 constant BIN_SWAP_EXACT_IN_SINGLE = 0x1c;
-    uint256 constant BIN_SWAP_EXACT_IN = 0x1d;
-    uint256 constant BIN_SWAP_EXACT_OUT_SINGLE = 0x1e;
-    uint256 constant BIN_SWAP_EXACT_OUT = 0x1f;
+    uint256 internal constant BIN_SWAP_EXACT_IN_SINGLE = 0x1c;
+    uint256 internal constant BIN_SWAP_EXACT_IN = 0x1d;
+    uint256 internal constant BIN_SWAP_EXACT_OUT_SINGLE = 0x1e;
+    uint256 internal constant BIN_SWAP_EXACT_OUT = 0x1f;
     // donate
-    uint256 constant BIN_DONATE = 0x20;
+    uint256 internal constant BIN_DONATE = 0x20;
 }

--- a/src/libraries/PathKey.sol
+++ b/src/libraries/PathKey.sol
@@ -16,6 +16,8 @@ struct PathKey {
     bytes32 parameters;
 }
 
+using PathKeyLibrary for PathKey global;
+
 library PathKeyLibrary {
     /// @notice Get the pool and swap direction for a given PathKey
     /// @param params the given PathKey

--- a/src/libraries/Planner.sol
+++ b/src/libraries/Planner.sol
@@ -12,10 +12,10 @@ struct Plan {
     bytes[] params;
 }
 
+using Planner for Plan global;
+
 /// @notice Constructs a plan of actions to be executed on Pancakeswap v4.
 library Planner {
-    using Planner for Plan;
-
     function init() internal pure returns (Plan memory plan) {
         return Plan({actions: bytes(""), params: new bytes[](0)});
     }

--- a/src/pool-bin/BinMigrator.sol
+++ b/src/pool-bin/BinMigrator.sol
@@ -15,7 +15,6 @@ import {ReentrancyLock} from "../base/ReentrancyLock.sol";
 
 contract BinMigrator is IBinMigrator, BaseMigrator, ReentrancyLock {
     using SafeCast for uint256;
-    using Planner for Plan;
 
     IBinPositionManager public immutable binPositionManager;
 

--- a/src/pool-bin/BinPositionManager.sol
+++ b/src/pool-bin/BinPositionManager.sol
@@ -8,7 +8,7 @@ import {Currency, CurrencyLibrary} from "pancake-v4-core/src/types/Currency.sol"
 import {IBinPoolManager} from "pancake-v4-core/src/pool-bin/interfaces/IBinPoolManager.sol";
 import {BinPool} from "pancake-v4-core/src/pool-bin/libraries/BinPool.sol";
 import {PoolKey} from "pancake-v4-core/src/types/PoolKey.sol";
-import {PoolId, PoolIdLibrary} from "pancake-v4-core/src/types/PoolId.sol";
+import {PoolId} from "pancake-v4-core/src/types/PoolId.sol";
 import {LiquidityConfigurations} from "pancake-v4-core/src/pool-bin/libraries/math/LiquidityConfigurations.sol";
 import {BinPoolParametersHelper} from "pancake-v4-core/src/pool-bin/libraries/BinPoolParametersHelper.sol";
 import {PackedUint128Math} from "pancake-v4-core/src/pool-bin/libraries/math/PackedUint128Math.sol";

--- a/src/pool-bin/BinRouterBase.sol
+++ b/src/pool-bin/BinRouterBase.sol
@@ -15,7 +15,6 @@ import {DeltaResolver} from "../base/DeltaResolver.sol";
 import {ActionConstants} from "../libraries/ActionConstants.sol";
 
 abstract contract BinRouterBase is IBinRouterBase, DeltaResolver {
-    using PathKeyLibrary for PathKey;
     using SafeCastTemp for *;
     using SafeCast for *;
 

--- a/src/pool-bin/lens/BinQuoter.sol
+++ b/src/pool-bin/lens/BinQuoter.sol
@@ -9,7 +9,7 @@ import {BalanceDelta} from "pancake-v4-core/src/types/BalanceDelta.sol";
 import {Currency} from "pancake-v4-core/src/types/Currency.sol";
 import {PoolKey} from "pancake-v4-core/src/types/PoolKey.sol";
 import {SafeCast} from "pancake-v4-core/src/pool-bin/libraries/math/SafeCast.sol";
-import {PoolId, PoolIdLibrary} from "pancake-v4-core/src/types/PoolId.sol";
+import {PoolId} from "pancake-v4-core/src/types/PoolId.sol";
 import {IBinQuoter} from "../interfaces/IBinQuoter.sol";
 import {PathKey, PathKeyLibrary} from "../../libraries/PathKey.sol";
 import {BaseV4Quoter} from "../../base/BaseV4Quoter.sol";
@@ -18,8 +18,6 @@ import {QuoterRevert} from "../../libraries/QuoterRevert.sol";
 contract BinQuoter is BaseV4Quoter, IBinQuoter {
     using QuoterRevert for *;
     using SafeCast for uint128;
-    using PathKeyLibrary for PathKey;
-    using PoolIdLibrary for PoolId;
 
     IBinPoolManager public immutable poolManager;
 

--- a/src/pool-cl/CLMigrator.sol
+++ b/src/pool-cl/CLMigrator.sol
@@ -16,8 +16,6 @@ import {Plan, Planner} from "../libraries/Planner.sol";
 import {ReentrancyLock} from "../base/ReentrancyLock.sol";
 
 contract CLMigrator is ICLMigrator, BaseMigrator, ReentrancyLock {
-    using Planner for Plan;
-
     ICLPositionManager public immutable clPositionManager;
     ICLPoolManager public immutable clPoolManager;
 

--- a/src/pool-cl/CLRouterBase.sol
+++ b/src/pool-cl/CLRouterBase.sol
@@ -15,7 +15,6 @@ import {DeltaResolver} from "../base/DeltaResolver.sol";
 import {ActionConstants} from "../libraries/ActionConstants.sol";
 
 abstract contract CLRouterBase is ICLRouterBase, DeltaResolver {
-    using PathKeyLibrary for PathKey;
     using SafeCastTemp for *;
 
     ICLPoolManager public immutable clPoolManager;

--- a/src/pool-cl/lens/CLQuoter.sol
+++ b/src/pool-cl/lens/CLQuoter.sol
@@ -6,7 +6,7 @@ import {TickMath} from "pancake-v4-core/src/pool-cl/libraries/TickMath.sol";
 import {ICLPoolManager} from "pancake-v4-core/src/pool-cl/interfaces/ICLPoolManager.sol";
 import {BalanceDelta} from "pancake-v4-core/src/types/BalanceDelta.sol";
 import {PoolKey} from "pancake-v4-core/src/types/PoolKey.sol";
-import {PoolId, PoolIdLibrary} from "pancake-v4-core/src/types/PoolId.sol";
+import {PoolId} from "pancake-v4-core/src/types/PoolId.sol";
 import {ICLQuoter} from "../interfaces/ICLQuoter.sol";
 import {PoolTicksCounter} from "../libraries/PoolTicksCounter.sol";
 import {PathKey, PathKeyLibrary} from "../../libraries/PathKey.sol";
@@ -16,8 +16,6 @@ import {Currency} from "pancake-v4-core/src/types/Currency.sol";
 
 contract CLQuoter is ICLQuoter, BaseV4Quoter {
     using QuoterRevert for *;
-    using PathKeyLibrary for PathKey;
-    using PoolIdLibrary for PoolId;
 
     ICLPoolManager public immutable poolManager;
 

--- a/src/pool-cl/lens/TickLens.sol
+++ b/src/pool-cl/lens/TickLens.sol
@@ -3,7 +3,7 @@
 pragma solidity 0.8.26;
 
 import {PoolKey} from "pancake-v4-core/src/types/PoolKey.sol";
-import {PoolId, PoolIdLibrary} from "pancake-v4-core/src/types/PoolId.sol";
+import {PoolId} from "pancake-v4-core/src/types/PoolId.sol";
 import {ICLPoolManager} from "pancake-v4-core/src/pool-cl/interfaces/ICLPoolManager.sol";
 import {CLPoolParametersHelper} from "pancake-v4-core/src/pool-cl/libraries/CLPoolParametersHelper.sol";
 import {Tick} from "pancake-v4-core/src/pool-cl/libraries/Tick.sol";
@@ -11,7 +11,6 @@ import {ITickLens} from "../interfaces/ITickLens.sol";
 
 /// @title Tick Lens contract
 contract TickLens is ITickLens {
-    using PoolIdLibrary for PoolId;
     using CLPoolParametersHelper for bytes32;
 
     ICLPoolManager public immutable poolManager;

--- a/src/pool-cl/libraries/PoolTicksCounter.sol
+++ b/src/pool-cl/libraries/PoolTicksCounter.sol
@@ -5,7 +5,6 @@ pragma solidity ^0.8.24;
 import {CLPoolParametersHelper} from "pancake-v4-core/src/pool-cl/libraries/CLPoolParametersHelper.sol";
 import {ICLPoolManager} from "pancake-v4-core/src/pool-cl/interfaces/ICLPoolManager.sol";
 import {PoolKey} from "pancake-v4-core/src/types/PoolKey.sol";
-import {PoolIdLibrary} from "pancake-v4-core/src/types/PoolId.sol";
 
 /// @title Pool Ticks Counter
 /// @notice Functions for counting the number of initialized ticks between two ticks

--- a/test/BaseActionsRouter.t.sol
+++ b/test/BaseActionsRouter.t.sol
@@ -9,8 +9,6 @@ import {Test} from "forge-std/Test.sol";
 import {IVault, Vault} from "pancake-v4-core/src/Vault.sol";
 
 contract BaseActionsRouterTest is Test {
-    using Planner for Plan;
-
     MockBaseActionsRouter router;
 
     function setUp() public {

--- a/test/MixedQuoter.t.sol
+++ b/test/MixedQuoter.t.sol
@@ -65,7 +65,6 @@ contract MixedQuoterTest is
     using SafeCast for *;
     using CLPoolParametersHelper for bytes32;
     using BinPoolParametersHelper for bytes32;
-    using Planner for Plan;
 
     error ContractSizeTooLarge(uint256 diff);
 

--- a/test/MixedQuoter.t.sol
+++ b/test/MixedQuoter.t.sol
@@ -1514,7 +1514,7 @@ contract MixedQuoterTest is
         (uint256 amountOut, uint256 gasEstimate) = mixedQuoter.quoteMixedExactInput(paths, actions, params, 1 ether);
 
         assertEq(amountOut, 901152761185198407);
-        assertGt(gasEstimate, 190000);
+        assertGt(gasEstimate, 180000);
         assertLt(gasEstimate, 200000);
     }
 

--- a/test/pool-bin/BinPositionManager_Delta.t.sol
+++ b/test/pool-bin/BinPositionManager_Delta.t.sol
@@ -34,7 +34,6 @@ import {BinPool} from "pancake-v4-core/src/pool-bin/libraries/BinPool.sol";
 
 // test on the various way to perform delta resolver
 contract BinPositionManager_DeltaTest is BinLiquidityHelper, TokenFixture, DeployPermit2 {
-    using Planner for Plan;
     using BinPoolParametersHelper for bytes32;
     using SafeCast for uint256;
     using BinTokenLibrary for PoolId;

--- a/test/pool-bin/BinPositionManager_ModifyLiqudiitiesWithoutLock.t.sol
+++ b/test/pool-bin/BinPositionManager_ModifyLiqudiitiesWithoutLock.t.sol
@@ -37,7 +37,6 @@ import {IWETH9} from "../../src/interfaces/external/IWETH9.sol";
 import {CustomRevert} from "pancake-v4-core/src/libraries/CustomRevert.sol";
 
 contract BinPositionManager_ModifyLiquidityWithoutLockTest is BinLiquidityHelper, TokenFixture, DeployPermit2 {
-    using Planner for Plan;
     using BinPoolParametersHelper for bytes32;
     using SafeCast for uint256;
     using BinTokenLibrary for PoolId;

--- a/test/pool-bin/BinPositionManager_ModifyLiquidites.t.sol
+++ b/test/pool-bin/BinPositionManager_ModifyLiquidites.t.sol
@@ -39,7 +39,6 @@ import {BinPool} from "pancake-v4-core/src/pool-bin/libraries/BinPool.sol";
 import {MockFOT} from "../mocks/MockFeeOnTransfer.sol";
 
 contract BinPositionManager_ModifyLiquidityTest is BinLiquidityHelper, TokenFixture, DeployPermit2 {
-    using Planner for Plan;
     using BinPoolParametersHelper for bytes32;
     using SafeCast for uint256;
     using BinTokenLibrary for PoolId;

--- a/test/pool-bin/BinPositionManager_MultiCall.t.sol
+++ b/test/pool-bin/BinPositionManager_MultiCall.t.sol
@@ -38,7 +38,6 @@ contract BinPositionManager_MultiCallTest is
     TokenFixture,
     DeployPermit2
 {
-    using Planner for Plan;
     using BinPoolParametersHelper for bytes32;
     using SafeCast for uint256;
     using BinTokenLibrary for PoolId;

--- a/test/pool-bin/BinPositionManager_NativeToken.t.sol
+++ b/test/pool-bin/BinPositionManager_NativeToken.t.sol
@@ -32,7 +32,6 @@ import {BinPool} from "pancake-v4-core/src/pool-bin/libraries/BinPool.sol";
 
 // test on the native token pair etc..
 contract BinPositionManager_NativeTokenTest is BinLiquidityHelper, DeployPermit2 {
-    using Planner for Plan;
     using BinPoolParametersHelper for bytes32;
     using SafeCast for uint256;
     using BinTokenLibrary for PoolId;

--- a/test/pool-bin/BinQuoter.t.sol
+++ b/test/pool-bin/BinQuoter.t.sol
@@ -35,9 +35,7 @@ import {IWETH9} from "../../src/interfaces/external/IWETH9.sol";
 
 contract BinQuoterTest is Test, BinLiquidityHelper, DeployPermit2 {
     using SafeCast for uint256;
-    using Planner for Plan;
     using BinPoolParametersHelper for bytes32;
-    using Planner for Plan;
 
     error ContractSizeTooLarge(uint256 diff);
 

--- a/test/pool-bin/BinSwapRouter.t.sol
+++ b/test/pool-bin/BinSwapRouter.t.sol
@@ -31,9 +31,7 @@ import {IWETH9} from "../../src/interfaces/external/IWETH9.sol";
 
 contract BinSwapRouterTest is Test, BinLiquidityHelper, DeployPermit2 {
     using SafeCast for uint256;
-    using Planner for Plan;
     using BinPoolParametersHelper for bytes32;
-    using Planner for Plan;
 
     bytes constant ZERO_BYTES = new bytes(0);
     uint256 _deadline = block.timestamp + 1;
@@ -403,7 +401,7 @@ contract BinSwapRouterTest is Test, BinLiquidityHelper, DeployPermit2 {
             data = plan.finalizeSwap(key.currency1, key.currency0, alice);
         }
         router.executeActions(data);
-        vm.snapshotGasLastCall("testExactOutputSingle_SwapForY");
+        vm.snapshotGasLastCall(gasSnapshotName);
 
         // amountIn is 501504513540621866
         if (swapForY) {

--- a/test/pool-bin/helper/BinLiquidityHelper.sol
+++ b/test/pool-bin/helper/BinLiquidityHelper.sol
@@ -18,7 +18,6 @@ import {BinPositionManager} from "../../../src/pool-bin/BinPositionManager.sol";
 import {Planner, Plan} from "../../../src/libraries/Planner.sol";
 
 contract BinLiquidityHelper is Test {
-    using Planner for Plan;
     using SafeCast for uint256;
 
     /// @dev helper method to approve token0/token1 of poolKey to binPositionManager

--- a/test/pool-cl/CLSwapRouter.t.sol
+++ b/test/pool-cl/CLSwapRouter.t.sol
@@ -25,8 +25,6 @@ import {Actions} from "../../src/libraries/Actions.sol";
 import {ActionConstants} from "../../src/libraries/ActionConstants.sol";
 
 contract CLSwapRouterTest is TokenFixture, Test {
-    using Planner for Plan;
-
     IVault public vault;
     ICLPoolManager public poolManager;
     CLPoolManagerRouter public positionManager;

--- a/test/pool-cl/TickLens.t.sol
+++ b/test/pool-cl/TickLens.t.sol
@@ -23,7 +23,6 @@ import {ITickLens} from "../../src/pool-cl/interfaces/ITickLens.sol";
 import {TickLens} from "../../src/pool-cl/lens/TickLens.sol";
 
 contract TickLensTest is TokenFixture, Test {
-    using Planner for Plan;
     using PoolIdLibrary for PoolId;
     using CLPoolParametersHelper for bytes32;
 

--- a/test/pool-cl/libraries/PositionInfoLibrary.t.sol
+++ b/test/pool-cl/libraries/PositionInfoLibrary.t.sol
@@ -3,12 +3,10 @@ pragma solidity ^0.8.24;
 
 import "forge-std/Test.sol";
 import {PoolKey} from "pancake-v4-core/src/types/PoolKey.sol";
-import {PoolIdLibrary} from "pancake-v4-core/src/types/PoolId.sol";
 import {CLPositionInfo, CLPositionInfoLibrary, PoolId} from "../../../src/pool-cl/libraries/CLPositionInfoLibrary.sol";
 
 contract PositionInfoLibraryTest is Test {
     using CLPositionInfoLibrary for CLPositionInfo;
-    using PoolIdLibrary for PoolKey;
 
     function setUp() public {}
 

--- a/test/pool-cl/mocks/MockCLBadSubscribers.sol
+++ b/test/pool-cl/mocks/MockCLBadSubscribers.sol
@@ -87,7 +87,7 @@ contract MockCLRevertSubscriber is ICLSubscriber {
         revert TestRevert("notifyUnsubscribe");
     }
 
-    function notifyBurn(uint256, address, CLPositionInfo, uint256, BalanceDelta) external {
+    function notifyBurn(uint256, address, CLPositionInfo, uint256, BalanceDelta) external pure {
         revert TestRevert("notifyBurn");
     }
 

--- a/test/pool-cl/mocks/MockCLSubscriber.sol
+++ b/test/pool-cl/mocks/MockCLSubscriber.sol
@@ -48,13 +48,10 @@ contract MockCLSubscriber is ICLSubscriber {
         feesAccrued = _feesAccrued;
     }
 
-    function notifyBurn(
-        uint256 tokenId,
-        address owner,
-        CLPositionInfo info,
-        uint256 _liquidity,
-        BalanceDelta _feesAccrued
-    ) external onlyByPosm {
+    function notifyBurn(uint256, address, CLPositionInfo, uint256 _liquidity, BalanceDelta _feesAccrued)
+        external
+        onlyByPosm
+    {
         liquidity = _liquidity;
         feesAccrued = _feesAccrued;
         notifyBurnCount++;

--- a/test/pool-cl/position-managers/CLPositionManager.gas.t.sol
+++ b/test/pool-cl/position-managers/CLPositionManager.gas.t.sol
@@ -33,7 +33,6 @@ import {MockCLSubscriber} from "../mocks/MockCLSubscriber.sol";
 
 contract CLPositionManagerGasTest is Test, PosmTestSetup {
     using FixedPointMathLib for uint256;
-    using Planner for Plan;
     using CLPoolParametersHelper for bytes32;
 
     IVault vault;

--- a/test/pool-cl/position-managers/CLPositionManager.increaseLiquidity.t.sol
+++ b/test/pool-cl/position-managers/CLPositionManager.increaseLiquidity.t.sol
@@ -30,7 +30,6 @@ import {ActionConstants} from "../../../src/libraries/ActionConstants.sol";
 
 contract CLPositionManagerIncreaseLiquidityTest is Test, PosmTestSetup, Fuzzers {
     using FixedPointMathLib for uint256;
-    using Planner for Plan;
     using FeeMath for ICLPositionManager;
 
     IVault vault;

--- a/test/pool-cl/position-managers/CLPositionManager.modifyLiquidity.t.sol
+++ b/test/pool-cl/position-managers/CLPositionManager.modifyLiquidity.t.sol
@@ -41,7 +41,6 @@ import {CLPoolParametersHelper} from "pancake-v4-core/src/pool-cl/libraries/CLPo
 import {BipsLibrary} from "../../../src/libraries/BipsLibrary.sol";
 
 contract CLPositionManagerModifyLiquiditiesTest is Test, PosmTestSetup, LiquidityFuzzers {
-    using Planner for Plan;
     using CLPoolParametersHelper for bytes32;
     using BipsLibrary for uint256;
 

--- a/test/pool-cl/position-managers/CLPositionManager.multicall.t.sol
+++ b/test/pool-cl/position-managers/CLPositionManager.multicall.t.sol
@@ -37,7 +37,6 @@ import {Permit2Forwarder} from "../../../src/base/Permit2Forwarder.sol";
 
 contract CLPositionManagerMulticallTest is Test, Permit2SignatureHelpers, PosmTestSetup, LiquidityFuzzers {
     using FixedPointMathLib for uint256;
-    using Planner for Plan;
     using CLPoolParametersHelper for bytes32;
 
     IVault vault;

--- a/test/pool-cl/position-managers/CLPositionManager.notifier.sol
+++ b/test/pool-cl/position-managers/CLPositionManager.notifier.sol
@@ -26,7 +26,6 @@ import {MockCLReenterHook} from "../mocks/MockCLReenterHook.sol";
 import {CustomRevert} from "pancake-v4-core/src/libraries/CustomRevert.sol";
 
 contract CLPositionManagerNotifierTest is Test, PosmTestSetup {
-    using Planner for Plan;
     using CLPositionInfoLibrary for CLPositionInfo;
 
     IVault vault;

--- a/test/pool-cl/position-managers/CLPositionManager.t.sol
+++ b/test/pool-cl/position-managers/CLPositionManager.t.sol
@@ -39,7 +39,6 @@ import {CLPositionDescriptorOffChain} from "../../../src/pool-cl/CLPositionDescr
 
 contract PositionManagerTest is Test, PosmTestSetup, LiquidityFuzzers {
     using FixedPointMathLib for uint256;
-    using Planner for Plan;
     using CLPoolParametersHelper for bytes32;
 
     error ContractSizeTooLarge(uint256 diff);

--- a/test/pool-cl/position-managers/Execute.t.sol
+++ b/test/pool-cl/position-managers/Execute.t.sol
@@ -29,7 +29,6 @@ import {PosmTestSetup} from "../shared/PosmTestSetup.sol";
 
 contract ExecuteTest is Test, PosmTestSetup, LiquidityFuzzers {
     using FixedPointMathLib for uint256;
-    using Planner for Plan;
 
     IVault vault;
     ICLPoolManager manager;

--- a/test/pool-cl/position-managers/NativeToken.t.sol
+++ b/test/pool-cl/position-managers/NativeToken.t.sol
@@ -34,7 +34,6 @@ import {LiquidityFuzzers} from "../shared/fuzz/LiquidityFuzzers.sol";
 
 contract NativeTokenTest is Test, PosmTestSetup, LiquidityFuzzers {
     using FixedPointMathLib for uint256;
-    using Planner for Plan;
     using SafeCast for *;
     using SafeCastTemp for *;
 

--- a/test/pool-cl/shared/CLLiquidityOperations.sol
+++ b/test/pool-cl/shared/CLLiquidityOperations.sol
@@ -16,7 +16,6 @@ import {HookSavesDelta} from "./HookSavesDelta.sol";
 import {ICLPositionDescriptor} from "../../../src/pool-cl/interfaces/ICLPositionDescriptor.sol";
 
 abstract contract CLLiquidityOperations is CommonBase {
-    using Planner for Plan;
     using SafeCastTemp for uint256;
 
     CLPositionManager lpm;

--- a/test/pool-cl/shared/fuzz/LiquidityFuzzers.sol
+++ b/test/pool-cl/shared/fuzz/LiquidityFuzzers.sol
@@ -14,7 +14,6 @@ import {Actions} from "../../../../src/libraries/Actions.sol";
 import {Planner, Plan} from "../../../../src/libraries/Planner.sol";
 
 contract LiquidityFuzzers is Fuzzers {
-    using Planner for Plan;
     using CLPoolParametersHelper for bytes32;
 
     function addFuzzyLiquidity(


### PR DESCRIPTION
This PR increase use `additional_compiler_profiles ` so CLPositionManager can remain at `9000` optimizer_runs while the other contracts can be at higher optimizer runs

this would reduce in gas for the other contracts