### PR TITLE
[Part 2 - option 2] feat: refactor v4 to infinity 

### DIFF
--- a/src/pool-cl/CLPositionManager.sol
+++ b/src/pool-cl/CLPositionManager.sol
@@ -21,7 +21,7 @@ import {ICLPositionManager} from "./interfaces/ICLPositionManager.sol";
 import {CalldataDecoder} from "../libraries/CalldataDecoder.sol";
 import {CLCalldataDecoder} from "./libraries/CLCalldataDecoder.sol";
 import {Actions} from "../libraries/Actions.sol";
-import {ERC721Permit_v4} from "./base/ERC721Permit_v4.sol";
+import {ERC721Permit_infi} from "./base/ERC721Permit_infi.sol";
 import {SlippageCheck} from "../libraries/SlippageCheck.sol";
 import {Multicall} from "../base/Multicall.sol";
 import {CLNotifier} from "./base/CLNotifier.sol";
@@ -37,7 +37,7 @@ import {TickMath} from "infinity-core/src/pool-cl/libraries/TickMath.sol";
 /// @notice Contract for modifying liquidity for PCS Infinity CL pools
 contract CLPositionManager is
     ICLPositionManager,
-    ERC721Permit_v4,
+    ERC721Permit_infi,
     Multicall,
     DeltaResolver,
     ReentrancyLock,
@@ -73,7 +73,7 @@ contract CLPositionManager is
     )
         BaseActionsRouter(_vault)
         Permit2Forwarder(_permit2)
-        ERC721Permit_v4("Pancakeswap Infinity Positions NFT", "PCS-INFINITY-POSM")
+        ERC721Permit_infi("Pancakeswap Infinity Positions NFT", "PCS-INFINITY-POSM")
         CLNotifier(_unsubscribeGasLimit)
         NativeWrapper(_weth9)
     {
@@ -357,7 +357,7 @@ contract CLPositionManager is
         _mint(poolKey, tickLower, tickUpper, liquidity, amount0Max, amount1Max, owner, hookData);
     }
 
-    /// @dev this is overloaded with ERC721Permit_v4._burn
+    /// @dev this is overloaded with ERC721Permit_infi._burn
     function _burn(uint256 tokenId, uint128 amount0Min, uint128 amount1Min, bytes calldata hookData)
         internal
         onlyIfApproved(msgSender(), tokenId)

--- a/src/pool-cl/base/EIP712_infi.sol
+++ b/src/pool-cl/base/EIP712_infi.sol
@@ -1,14 +1,14 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 
-import {IEIP712_v4} from "../interfaces/IEIP712_v4.sol";
+import {IEIP712_infi} from "../interfaces/IEIP712_infi.sol";
 
 /// @notice Generic EIP712 implementation
 /// @dev Maintains cross-chain replay protection in the event of a fork
 /// @dev Should not be delegatecall'd because DOMAIN_SEPARATOR returns the cached hash and does not recompute with the delegatecallers address
 /// @dev Reference: https://github.com/pancakeswap/permit2/blob/main/src/EIP712.sol
 /// @dev Reference: https://github.com/OpenZeppelin/openzeppelin-contracts/blob/master/contracts/utils/cryptography/EIP712.sol
-contract EIP712_v4 is IEIP712_v4 {
+contract EIP712_infi is IEIP712_infi {
     // Cache the domain separator as an immutable value, but also store the chain id that it
     // corresponds to, in order to invalidate the cached domain separator if the chain id changes.
     bytes32 private immutable _CACHED_DOMAIN_SEPARATOR;
@@ -25,7 +25,7 @@ contract EIP712_v4 is IEIP712_v4 {
         _CACHED_DOMAIN_SEPARATOR = _buildDomainSeparator();
     }
 
-    /// @inheritdoc IEIP712_v4
+    /// @inheritdoc IEIP712_infi
     function DOMAIN_SEPARATOR() public view override returns (bytes32) {
         // uses cached version if chainid is unchanged from construction
         return block.chainid == _CACHED_CHAIN_ID ? _CACHED_DOMAIN_SEPARATOR : _buildDomainSeparator();

--- a/src/pool-cl/base/ERC721Permit_infi.sol
+++ b/src/pool-cl/base/ERC721Permit_infi.sol
@@ -6,17 +6,17 @@ import {ERC721} from "solmate/src/tokens/ERC721.sol";
 import {ERC721PermitHash} from "../libraries/ERC721PermitHash.sol";
 import {SignatureVerification} from "permit2/src/libraries/SignatureVerification.sol";
 
-import {EIP712_v4} from "./EIP712_v4.sol";
-import {IERC721Permit_v4} from "../interfaces/IERC721Permit_v4.sol";
+import {EIP712_infi} from "./EIP712_infi.sol";
+import {IERC721Permit_infi} from "../interfaces/IERC721Permit_infi.sol";
 import {UnorderedNonce} from "./UnorderedNonce.sol";
 
 /// @title ERC721 with permit
 /// @notice Nonfungible tokens that support an approve via signature, i.e. permit
-abstract contract ERC721Permit_v4 is ERC721, IERC721Permit_v4, EIP712_v4, UnorderedNonce {
+abstract contract ERC721Permit_infi is ERC721, IERC721Permit_infi, EIP712_infi, UnorderedNonce {
     using SignatureVerification for bytes;
 
     /// @notice Computes the nameHash and versionHash
-    constructor(string memory name_, string memory symbol_) ERC721(name_, symbol_) EIP712_v4(name_) {}
+    constructor(string memory name_, string memory symbol_) ERC721(name_, symbol_) EIP712_infi(name_) {}
 
     /// @notice Checks if the block's timestamp is before a signature's deadline
     modifier checkSignatureDeadline(uint256 deadline) {
@@ -24,7 +24,7 @@ abstract contract ERC721Permit_v4 is ERC721, IERC721Permit_v4, EIP712_v4, Unorde
         _;
     }
 
-    /// @inheritdoc IERC721Permit_v4
+    /// @inheritdoc IERC721Permit_infi
     function permit(address spender, uint256 tokenId, uint256 deadline, uint256 nonce, bytes calldata signature)
         external
         payable
@@ -40,7 +40,7 @@ abstract contract ERC721Permit_v4 is ERC721, IERC721Permit_v4, EIP712_v4, Unorde
         _approve(owner, spender, tokenId);
     }
 
-    /// @inheritdoc IERC721Permit_v4
+    /// @inheritdoc IERC721Permit_infi
     function permitForAll(
         address owner,
         address operator,

--- a/src/pool-cl/interfaces/IEIP712_infi.sol
+++ b/src/pool-cl/interfaces/IEIP712_infi.sol
@@ -2,7 +2,7 @@
 pragma solidity ^0.8.0;
 
 /// @notice This interface is used for an EIP712 implementation
-interface IEIP712_v4 {
+interface IEIP712_infi {
     /// @notice Returns the domain separator for the current chain.
     /// @dev Uses cached version if chainid is unchanged from construction.
     function DOMAIN_SEPARATOR() external view returns (bytes32);

--- a/src/pool-cl/interfaces/IERC721Permit_infi.sol
+++ b/src/pool-cl/interfaces/IERC721Permit_infi.sol
@@ -3,7 +3,7 @@ pragma solidity ^0.8.0;
 
 /// @title ERC721 with permit
 /// @notice Extension to ERC721 that includes a permit function for signature based approvals
-interface IERC721Permit_v4 {
+interface IERC721Permit_infi {
     error SignatureDeadlineExpired();
     error NoSelfPermit();
     error Unauthorized();

--- a/src/pool-cl/libraries/ERC721PermitHash.sol
+++ b/src/pool-cl/libraries/ERC721PermitHash.sol
@@ -9,7 +9,7 @@ library ERC721PermitHash {
     /// @dev Value is equal to keccak256("PermitForAll(address operator,bool approved,uint256 nonce,uint256 deadline)");
     bytes32 constant PERMIT_FOR_ALL_TYPEHASH = 0x6673cb397ee2a50b6b8401653d3638b4ac8b3db9c28aa6870ffceb7574ec2f76;
 
-    /// @notice Hashes the data that will be signed for IERC721Permit_v4.permit()
+    /// @notice Hashes the data that will be signed for IERC721Permit_infi.permit()
     /// @param spender The address which may spend the tokenId
     /// @param tokenId The tokenId of the owner, which may be spent by spender
     /// @param nonce A unique non-ordered value for each signature to prevent replay attacks
@@ -39,7 +39,7 @@ library ERC721PermitHash {
         }
     }
 
-    /// @notice Hashes the data that will be signed for IERC721Permit_v4.permit()
+    /// @notice Hashes the data that will be signed for IERC721Permit_infi.permit()
     /// @param operator The address which may spend any of the owner's tokenIds
     /// @param approved true if the operator is to have full permission over the owner's tokenIds; false otherwise
     /// @param nonce A unique non-ordered value for each signature to prevent replay attacks

--- a/test/pool-cl/EIP712.t.sol
+++ b/test/pool-cl/EIP712.t.sol
@@ -3,10 +3,10 @@ pragma solidity ^0.8.20;
 
 import "forge-std/Test.sol";
 
-import {EIP712_v4} from "../../src/pool-cl/base/EIP712_v4.sol";
+import {EIP712_infi} from "../../src/pool-cl/base/EIP712_infi.sol";
 
-contract EIP712Test is EIP712_v4, Test {
-    constructor() EIP712_v4("EIP712Test") {}
+contract EIP712Test is EIP712_infi, Test {
+    constructor() EIP712_infi("EIP712Test") {}
 
     function setUp() public {}
 

--- a/test/pool-cl/erc721Permit/ERC721Permit.permit.t.sol
+++ b/test/pool-cl/erc721Permit/ERC721Permit.permit.t.sol
@@ -6,7 +6,7 @@ import {SignatureVerification} from "permit2/src/libraries/SignatureVerification
 
 import {ERC721PermitHash} from "../../../src/pool-cl/libraries/ERC721PermitHash.sol";
 import {MockERC721Permit} from "../mocks/MockERC721Permit.sol";
-import {IERC721Permit_v4} from "../../../src/pool-cl/interfaces/IERC721Permit_v4.sol";
+import {IERC721Permit_infi} from "../../../src/pool-cl/interfaces/IERC721Permit_infi.sol";
 import {IERC721} from "forge-std/interfaces/IERC721.sol";
 import {UnorderedNonce} from "../../../src/pool-cl/base/UnorderedNonce.sol";
 
@@ -17,7 +17,7 @@ contract ERC721PermitTest is Test {
     address bob;
     uint256 bobPK;
 
-    string constant name = "Mock ERC721Permit_v4";
+    string constant name = "Mock ERC721Permit_infi";
     string constant symbol = "MOCK721";
 
     function setUp() public {
@@ -54,7 +54,7 @@ contract ERC721PermitTest is Test {
     function test_fuzz_approve_unauthorizedRevert(address caller) public {
         uint256 tokenId = erc721Permit.mint();
         vm.prank(caller);
-        if (caller != address(this)) vm.expectRevert(IERC721Permit_v4.Unauthorized.selector);
+        if (caller != address(this)) vm.expectRevert(IERC721Permit_infi.Unauthorized.selector);
         erc721Permit.approve(address(this), tokenId);
     }
 
@@ -254,7 +254,7 @@ contract ERC721PermitTest is Test {
 
         // -- Permit but deadline expired -- //
         vm.startPrank(spender);
-        vm.expectRevert(IERC721Permit_v4.SignatureDeadlineExpired.selector);
+        vm.expectRevert(IERC721Permit_infi.SignatureDeadlineExpired.selector);
         erc721Permit.permit(spender, tokenId, deadline, nonce, signature);
         vm.stopPrank();
 

--- a/test/pool-cl/erc721Permit/ERC721Permit.permitForAll.t.sol
+++ b/test/pool-cl/erc721Permit/ERC721Permit.permitForAll.t.sol
@@ -6,7 +6,7 @@ import {SignatureVerification} from "permit2/src/libraries/SignatureVerification
 
 import {ERC721PermitHash} from "../../../src/pool-cl/libraries/ERC721PermitHash.sol";
 import {MockERC721Permit} from "../mocks/MockERC721Permit.sol";
-import {IERC721Permit_v4} from "../../../src/pool-cl/interfaces/IERC721Permit_v4.sol";
+import {IERC721Permit_infi} from "../../../src/pool-cl/interfaces/IERC721Permit_infi.sol";
 import {IERC721} from "forge-std/interfaces/IERC721.sol";
 import {UnorderedNonce} from "../../../src/pool-cl/base/UnorderedNonce.sol";
 
@@ -17,7 +17,7 @@ contract ERC721PermitForAllTest is Test {
     address bob;
     uint256 bobPK;
 
-    string constant name = "Mock ERC721Permit_v4";
+    string constant name = "Mock ERC721Permit_infi";
     string constant symbol = "MOCK721";
 
     function setUp() public {
@@ -193,7 +193,7 @@ contract ERC721PermitForAllTest is Test {
 
         // -- PermitForAll but deadline expired -- //
         vm.startPrank(operator);
-        vm.expectRevert(IERC721Permit_v4.SignatureDeadlineExpired.selector);
+        vm.expectRevert(IERC721Permit_infi.SignatureDeadlineExpired.selector);
         erc721Permit.permitForAll(alice, operator, true, deadline, nonce, signature);
         vm.stopPrank();
 

--- a/test/pool-cl/mocks/MockERC721Permit.sol
+++ b/test/pool-cl/mocks/MockERC721Permit.sol
@@ -1,12 +1,12 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 pragma solidity ^0.8.20;
 
-import {ERC721Permit_v4} from "../../../src/pool-cl/base/ERC721Permit_v4.sol";
+import {ERC721Permit_infi} from "../../../src/pool-cl/base/ERC721Permit_infi.sol";
 
-contract MockERC721Permit is ERC721Permit_v4 {
+contract MockERC721Permit is ERC721Permit_infi {
     uint256 public lastTokenId;
 
-    constructor(string memory name, string memory symbol) ERC721Permit_v4(name, symbol) {}
+    constructor(string memory name, string memory symbol) ERC721Permit_infi(name, symbol) {}
 
     function mint() external returns (uint256 tokenId) {
         tokenId = ++lastTokenId;

--- a/test/pool-cl/position-managers/CLPositionManager.multicall.t.sol
+++ b/test/pool-cl/position-managers/CLPositionManager.multicall.t.sol
@@ -20,7 +20,7 @@ import {CLPoolParametersHelper} from "infinity-core/src/pool-cl/libraries/CLPool
 
 import {IERC20} from "forge-std/interfaces/IERC20.sol";
 
-import {IERC721Permit_v4} from "../../../src/pool-cl/base/ERC721Permit_v4.sol";
+import {IERC721Permit_infi} from "../../../src/pool-cl/interfaces/IERC721Permit_infi.sol";
 import {IMulticall} from "../../../src/interfaces/IMulticall.sol";
 import {CLPositionManager} from "../../../src/pool-cl/CLPositionManager.sol";
 import {IPositionManager} from "../../../src/interfaces/IPositionManager.sol";
@@ -250,7 +250,7 @@ contract CLPositionManagerMulticallTest is Test, Permit2SignatureHelpers, PosmTe
         // bob gives himself permission and decreases liquidity
         bytes[] memory calls = new bytes[](2);
         calls[0] = abi.encodeWithSelector(
-            IERC721Permit_v4(lpm).permit.selector, bob, tokenId, block.timestamp + 1, nonce, signature
+            IERC721Permit_infi(lpm).permit.selector, bob, tokenId, block.timestamp + 1, nonce, signature
         );
         uint256 liquidityToRemove = 0.4444e18;
         bytes memory actions = getDecreaseEncoded(tokenId, liquidityToRemove, ZERO_BYTES);

--- a/test/pool-cl/position-managers/Permit.t.sol
+++ b/test/pool-cl/position-managers/Permit.t.sol
@@ -14,8 +14,8 @@ import {SignatureVerification} from "permit2/src/libraries/SignatureVerification
 import {IVault} from "infinity-core/src/interfaces/IVault.sol";
 
 import {IERC20} from "forge-std/interfaces/IERC20.sol";
-import {IERC721Permit_v4} from "../../../src/pool-cl/interfaces/IERC721Permit_v4.sol";
-import {ERC721Permit_v4} from "../../../src/pool-cl/base/ERC721Permit_v4.sol";
+import {IERC721Permit_infi} from "../../../src/pool-cl/interfaces/IERC721Permit_infi.sol";
+import {ERC721Permit_infi} from "../../../src/pool-cl/base/ERC721Permit_infi.sol";
 import {UnorderedNonce} from "../../../src/pool-cl/base/UnorderedNonce.sol";
 
 import {ICLPositionManager} from "../../../src/pool-cl/interfaces/ICLPositionManager.sol";
@@ -60,7 +60,7 @@ contract PermitTest is Test, PosmTestSetup {
 
     function test_domainSeparator() public view {
         assertEq(
-            ERC721Permit_v4(address(lpm)).DOMAIN_SEPARATOR(),
+            ERC721Permit_infi(address(lpm)).DOMAIN_SEPARATOR(),
             keccak256(
                 abi.encode(
                     keccak256("EIP712Domain(string name,uint256 chainId,address verifyingContract)"),


### PR DESCRIPTION
This PR does the following:

- [x] rename `src/pool-cl/interfaces/IEIP712_v4` to `src/pool-cl/interfaces/IEIP712_infi`
- [x] rename `src/pool-cl/interfaces/IEIP712Permit_v4` to `src/pool-cl/interfaces/IEIP712Permit_infi`


This is option 2: 
- Option 1: Rename _v4 to be without suffix (but might collide if hardhat import) - https://github.com/pancakeswap/infinity-periphery/pull/78

- Option 2: Rename _v4 to _infi - https://github.com/pancakeswap/infinity-periphery/pull/79 